### PR TITLE
remove direct use of suspense and replace for loading components

### DIFF
--- a/src/app/(provider)/provider/signup/loading.tsx
+++ b/src/app/(provider)/provider/signup/loading.tsx
@@ -1,0 +1,11 @@
+import UserPage from '@/app/(user)/components/user-page';
+import Loading from '@/components/ui/loading';
+import React from 'react';
+
+export default function LoadingPage() {
+  return (
+    <UserPage>
+      <Loading />
+    </UserPage>
+  );
+}

--- a/src/app/(provider)/provider/signup/page.tsx
+++ b/src/app/(provider)/provider/signup/page.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
 import UserPage from '@/app/(user)/components/user-page';
 import ProviderSignupForm from '@/app/(provider)/provider/signup/components/provider-signup-form';
@@ -25,9 +25,7 @@ async function ProviderSignupPageInternal() {
 export default function ProviderSignupPage() {
   return (
     <UserPage>
-      <Suspense fallback={<p>Loading...</p>}>
-        <ProviderSignupPageInternal />
-      </Suspense>
+      <ProviderSignupPageInternal />
     </UserPage>
   );
 }

--- a/src/app/(provider)/settings/provider/loading.tsx
+++ b/src/app/(provider)/settings/provider/loading.tsx
@@ -1,0 +1,11 @@
+import UserPage from '@/app/(user)/components/user-page';
+import Loading from '@/components/ui/loading';
+import React from 'react';
+
+export default function LoadingPage() {
+  return (
+    <UserPage>
+      <Loading />
+    </UserPage>
+  );
+}

--- a/src/app/(provider)/settings/provider/page.tsx
+++ b/src/app/(provider)/settings/provider/page.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
 import UserPage from '@/app/(user)/components/user-page';
 import { fetchUserProfile } from '@/app/(user)/settings/profile/actions';
@@ -25,9 +25,7 @@ async function ProviderSettingsPageInternal() {
 export default function ProviderSettingsPage() {
   return (
     <UserPage>
-      <Suspense fallback={<p>Loading...</p>}>
-        <ProviderSettingsPageInternal />
-      </Suspense>
+      <ProviderSettingsPageInternal />
     </UserPage>
   );
 }

--- a/src/app/(user)/chat/[id]/loading.tsx
+++ b/src/app/(user)/chat/[id]/loading.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import Chat from './components/chat';
+
+export default function LoadingChatPage() {
+  return <Chat />;
+}

--- a/src/app/(user)/chat/[id]/page.tsx
+++ b/src/app/(user)/chat/[id]/page.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
 import { redirect } from 'next/navigation';
 import { fetchChatMessages } from '../actions';
@@ -44,9 +44,5 @@ export default async function SingleChatPage({
 }) {
   const id = (await params).id;
 
-  return (
-    <Suspense fallback={<Chat />}>
-      <SingleChatPageInternal id={id} />
-    </Suspense>
-  );
+  return <SingleChatPageInternal id={id} />;
 }

--- a/src/app/(user)/chat/layout.tsx
+++ b/src/app/(user)/chat/layout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
 import UserPage from '../components/user-page';
 import ChatLayoutClient from './components/chat-layout-client';
@@ -6,7 +6,6 @@ import { getAuthUser } from '@/app/(auth)/utils';
 import { fetchUserChats } from './actions';
 import { redirect } from 'next/navigation';
 import { RecentChatStoreProvider } from '@/utils/hooks/use-recent-chat-store';
-import Loading from '@/components/ui/loading';
 
 async function ChatLayoutInternal({ children }: React.PropsWithChildren) {
   const { user } = await getAuthUser();
@@ -39,9 +38,7 @@ export default function ChatLayout({
 }>) {
   return (
     <UserPage>
-      <Suspense fallback={<Loading />}>
-        <ChatLayoutInternal>{children}</ChatLayoutInternal>
-      </Suspense>
+      <ChatLayoutInternal>{children}</ChatLayoutInternal>
     </UserPage>
   );
 }

--- a/src/app/(user)/chat/loading.tsx
+++ b/src/app/(user)/chat/loading.tsx
@@ -1,0 +1,11 @@
+import Loading from '@/components/ui/loading';
+import React from 'react';
+import UserPage from '../components/user-page';
+
+export default function LoadingChatPages() {
+  return (
+    <UserPage>
+      <Loading />
+    </UserPage>
+  );
+}

--- a/src/app/(user)/settings/profile/loading.tsx
+++ b/src/app/(user)/settings/profile/loading.tsx
@@ -1,0 +1,11 @@
+import Loading from '@/components/ui/loading';
+import React from 'react';
+import UserPage from '../../components/user-page';
+
+export default function LoadingPage() {
+  return (
+    <UserPage>
+      <Loading />
+    </UserPage>
+  );
+}

--- a/src/app/(user)/settings/profile/page.tsx
+++ b/src/app/(user)/settings/profile/page.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
 import { redirect } from 'next/navigation';
 import UserInfoForm from './components/user-info-form';
@@ -24,9 +24,7 @@ async function UserProfilePageInternal() {
 export default function UserProfilePage() {
   return (
     <UserPage>
-      <Suspense fallback={<Loading />}>
-        <UserProfilePageInternal />
-      </Suspense>
+      <UserProfilePageInternal />
     </UserPage>
   );
 }

--- a/src/app/providers/loading.tsx
+++ b/src/app/providers/loading.tsx
@@ -1,0 +1,11 @@
+import Loading from '@/components/ui/loading';
+import React from 'react';
+import UserPage from '../(user)/components/user-page';
+
+export default function LoadingPage() {
+  return (
+    <UserPage>
+      <Loading />
+    </UserPage>
+  );
+}

--- a/src/app/providers/page.tsx
+++ b/src/app/providers/page.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
 import UserPage from '../(user)/components/user-page';
 import { fetchAllActiveProviders } from './actions';
@@ -23,9 +23,7 @@ async function ProvidersPageInternal() {
 export default async function ProvidersPage() {
   return (
     <UserPage>
-      <Suspense fallback={<Loading />}>
-        <ProvidersPageInternal />
-      </Suspense>
+      <ProvidersPageInternal />
     </UserPage>
   );
 }

--- a/src/app/providers/profile/[id]/loading.tsx
+++ b/src/app/providers/profile/[id]/loading.tsx
@@ -1,0 +1,11 @@
+import UserPage from '@/app/(user)/components/user-page';
+import Loading from '@/components/ui/loading';
+import React from 'react';
+
+export default function LoadingPage() {
+  return (
+    <UserPage>
+      <Loading />
+    </UserPage>
+  );
+}

--- a/src/app/providers/profile/[id]/page.tsx
+++ b/src/app/providers/profile/[id]/page.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
 import UserPage from '@/app/(user)/components/user-page';
 import { fetchProviderProfile } from '../actions';
@@ -26,48 +26,46 @@ export default async function Page({
   return (
     <UserPage>
       {loading && <Loading />}
-      <Suspense fallback={<Loading />}>
-        <Card>
-          <CardHeader>
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-              }}
-            >
-              <CardTitle>
-                <AvatarTemplate
-                  fallbackName={data.provider.user?.full_name ?? ''}
-                >
-                  {data.provider.user?.full_name}
-                </AvatarTemplate>
-              </CardTitle>
-              <div style={{ textAlign: 'right' }}>
-                {data.provider.account_status === 'active' && (
-                  <FollowButton
-                    provider={data.provider}
-                    isFollowing={isFollowing}
-                  />
-                )}
-              </div>
+      <Card>
+        <CardHeader>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <CardTitle>
+              <AvatarTemplate
+                fallbackName={data.provider.user?.full_name ?? ''}
+              >
+                {data.provider.user?.full_name}
+              </AvatarTemplate>
+            </CardTitle>
+            <div style={{ textAlign: 'right' }}>
+              {data.provider.account_status === 'active' && (
+                <FollowButton
+                  provider={data.provider}
+                  isFollowing={isFollowing}
+                />
+              )}
             </div>
-          </CardHeader>
-          <CardContent>
-            <div>
-              <p>
-                <strong>Provider Degree:</strong> {data.provider.degree}
-              </p>
-              <p>
-                <strong>Provider Cedula:</strong> {data.provider.cedula}
-              </p>
-            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div>
             <p>
-              <strong>Provider Email:</strong> {data.provider.user?.email}
+              <strong>Provider Degree:</strong> {data.provider.degree}
             </p>
-          </CardContent>
-        </Card>
-      </Suspense>
+            <p>
+              <strong>Provider Cedula:</strong> {data.provider.cedula}
+            </p>
+          </div>
+          <p>
+            <strong>Provider Email:</strong> {data.provider.user?.email}
+          </p>
+        </CardContent>
+      </Card>
     </UserPage>
   );
 }


### PR DESCRIPTION
Looks like there's a bug on the suspense usage for app router, the data can get stuck at this state for the second navigation, usage of loading page seems to fix it, this also gives us room to provide better loading skeletons