### PR TITLE
remove loading animation for faster ui

### DIFF
--- a/src/components/site-page.tsx
+++ b/src/components/site-page.tsx
@@ -1,11 +1,9 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
 import { AppSidebar } from '@/components/app-sidebar';
 import { SiteHeader } from '@/components/site-header';
 import { SidebarProvider } from '@/components/ui/sidebar';
-import Loading from './ui/loading';
 import { User } from '@/utils/types';
-import PageLoadingWrapper from './page-loading-wrapper';
 
 type Props = React.PropsWithChildren<{
   user?: User | undefined;
@@ -18,11 +16,7 @@ export default async function SitePage({ children, user }: Props) {
         <SiteHeader />
         <div className='flex flex-1'>
           <AppSidebar user={user} />
-          <PageLoadingWrapper>
-            <div className='flex flex-1 flex-col gap-4 p-4'>
-              <Suspense fallback={<Loading />}>{children}</Suspense>
-            </div>
-          </PageLoadingWrapper>
+          <div className='flex flex-1 flex-col gap-4 p-4'>{children}</div>
         </div>
       </SidebarProvider>
     </div>

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 
 import { useSidebar } from './sidebar';
-import { useLoading } from '@/utils/hooks/use-loading';
 import NextLink from 'next/link';
 
 type Props = React.PropsWithChildren<{
@@ -13,13 +12,7 @@ type Props = React.PropsWithChildren<{
 
 export default function Link({ href, children, className }: Props) {
   const { isMobile, setOpenMobile } = useSidebar();
-  const { setLoading } = useLoading();
-
   const handleClick = () => {
-    setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
-    }, 1500);
     if (isMobile) {
       setOpenMobile(false);
     }


### PR DESCRIPTION
previously the animation was needed because the app router felt really slow, with the optimizations of caching the user data and using loading.tsx components the app feels much faster, now the spinnes makes it feel slower than it should be. 